### PR TITLE
changed puppeteer to puppeteer-core

### DIFF
--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -1,4 +1,4 @@
-const puppeteer = require('puppeteer');
+const puppeteer = require('puppeteer-core');
 const { expect } = require('chai');
 const opn = require('opn');
 const cmd = require('node-cmd');


### PR DESCRIPTION
npm install downloaded puppeteer-core and not puppeteer. When we run npm test, we are getting error that "cannot find module : puppeteer"